### PR TITLE
feat: bump debian, docker, actions runner

### DIFF
--- a/image/init.sh
+++ b/image/init.sh
@@ -11,6 +11,7 @@ RUNNER_USER="runner"
 sudo useradd -m $RUNNER_USER
 
 ## Minimum tools
+echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selections
 sudo apt-get -y update
 sudo apt-get -y install \
     git \
@@ -30,7 +31,7 @@ sudo add-apt-repository \
    $(lsb_release -cs) \
    stable"
 sudo apt-get -y update
-DOCKER_VERSION="5:19.03.14~3-0~debian-buster"
+DOCKER_VERSION="5:23.0.5-1~debian.11~bullseye"
 sudo apt-get -y install docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io
 sudo systemctl start docker
 sudo systemctl enable docker
@@ -47,7 +48,11 @@ sudo apt-get install -y 'stackdriver-agent=6.*'
 ## Runner
 cd /home/$RUNNER_USER
 sudo -u $RUNNER_USER mkdir actions-runner && cd "$_"
-ACTIONS_RUNNER_URL=$(curl -sL https://api.github.com/repos/actions/runner/releases/latest | jq -r '.assets[] | select(.name | contains("actions-runner-linux-x64")) | .browser_download_url')
+ACTIONS_RUNNER_DATA=$(curl -sL https://api.github.com/repos/actions/runner/releases/latest)
+# Get latest runner version, omitting the version prefix (v)
+ACTIONS_RUNNER_LATEST_VERSION=$(jq -r '.tag_name' <<< "$ACTIONS_RUNNER_DATA" | cut -c 2-)
+ACTIONS_RUNNER_URL=$(jq -r --arg latest_version "$ACTIONS_RUNNER_LATEST_VERSION" '.assets[] | select(.name | contains("actions-runner-linux-x64-" + $latest_version + ".tar.gz")) | .browser_download_url' <<< "$ACTIONS_RUNNER_DATA")
+echo "Download latest runner version from $ACTIONS_RUNNER_URL"
 sudo -u $RUNNER_USER curl -O -L "$ACTIONS_RUNNER_URL"
 sudo -u $RUNNER_USER tar xzf ./actions-runner-linux-x64-*.tar.gz
 exit 0

--- a/image/runner.json
+++ b/image/runner.json
@@ -11,7 +11,7 @@
         "type": "googlecompute",
         "project_id": "{{user `project_id`}}",
         "machine_type": "{{user `machine_type`}}",
-        "source_image_family": "debian-10",
+        "source_image_family": "debian-11",
         "region": "{{user `region`}}",
         "zone": "{{user `zone`}}",
         "image_description": "Runner for GitHub Action",


### PR DESCRIPTION
the runner image now uses :
- Debian 11 (Bullseye)
- Docker 23.0.5
- Github Actions Runner 2.304.0